### PR TITLE
Allow use of old-style 'get' method callback via environment variable

### DIFF
--- a/src/commands/getElValue.js
+++ b/src/commands/getElValue.js
@@ -33,7 +33,11 @@ GetElValue.prototype.pass = function (actual) {
   });
 
   if (this.cb) {
-    this.cb.apply(this.client.api, [actual, this.selector]);
+    if (Number(process.env.NIGHTWATCH_EXTRA_OLD_CALLBACK)) {
+      this.cb.apply(this.client.api, [actual.actual, this.selector]);
+    } else {
+      this.cb.apply(this.client.api, [actual, this.selector]);
+    }
   }
   this.emit("complete");
 };

--- a/tests/src/commands/getElValue.test.js
+++ b/tests/src/commands/getElValue.test.js
@@ -88,6 +88,33 @@ describe("GetElValue", () => {
     expect(getElValue.cmd).to.equal("getelvalue");
   });
 
+  describe("Pass old style", () => {
+    beforeEach(() => {
+      process.env.NIGHTWATCH_EXTRA_OLD_CALLBACK = 1;
+    });
+
+    afterEach(() => {
+      process.env.NIGHTWATCH_EXTRA_OLD_CALLBACK = 0;
+    });
+
+    it("Sync", () => {
+      getElValue = new GetElValue(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      getElValue.command("[name='q']", (value) => {
+         expect(value).to.equal("fake_element_value");
+      });
+    });
+
+    it("Async", () => {
+      getElValue = new GetElValue(clientMock);
+
+      getElValue.command("[name='q']", (value) => {
+        expect(value).to.equal("fake_element_value");
+      });
+    });
+  });
+
   describe("Pass", () => {
     it("Sync", () => {
       getElValue = new GetElValue(clientMock, {


### PR DESCRIPTION
Not everyone is ready to step up to nightwatch-extra 5.x - specifically the 'get*Value' commands changed the way the callback value is passed - it's now an object with an 'actual' property instead of just the 'actual' property itself.
By setting the environment variable `NIGHTWATCH_EXTRA_OLD_CALLBACK=1` the old-style callback is restored. 
The only non-mobile command that does this is `getElValue` so only implemented it for that one (there are a couple in the `mobile` namespace/directory) - if needed can be added to those later.
But have a pressing need for this now.